### PR TITLE
Test repaired for using under python 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ install:
   - pip install tox
 
 env:
-  - TOX_ENV=test
+  - TOX_ENV=py27
+  - TOX_ENV=py33
+  - TOX_ENV=py34
 
 script:
   - tox -e $TOX_ENV

--- a/test/test_nameko_socket_server.py
+++ b/test/test_nameko_socket_server.py
@@ -23,9 +23,9 @@ def test_server(container_factory):
     container.start()
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.connect(('', 6000))
-    sock.sendall('hello\n')
-    data = sock.recv(1024)
+    sock.connect(('127.0.0.1', 6000))
+    sock.sendall('hello\n'.encode('utf-8'))
+    data = sock.recv(1024).decode('utf-8')
     sock.close()
     assert data == 'hello world'
     container.stop()
@@ -39,9 +39,9 @@ def test_unknown_command(container_factory):
     container.start()
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.connect(('', 6000))
-    sock.sendall('unknown\n')
-    data = sock.recv(1024)
+    sock.connect(('127.0.0.1', 6000))
+    sock.sendall('unknown\n'.encode('utf-8'))
+    data = sock.recv(1024).decode('utf-8')
     sock.close()
     assert data == 'unknown command `unknown`'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = test
+envlist = {py27,py33,py34}
 skipsdist = True
 
 [testenv]
-deps =
-    test: nameko>=2.0.0  # need something
+deps = nameko>=2.0.0  # need something
 
 commands =
     pip install --editable .[dev]


### PR DESCRIPTION
Test of socket extension didn't work under python 3.x without decode/encode to/from byte string and without definition of localhost address. 
